### PR TITLE
Incorrect use of react-native in CountDownText.js

### DIFF
--- a/CountDownText.js
+++ b/CountDownText.js
@@ -11,15 +11,15 @@ this.refs.countDownText.end();
 */
 
 'use strict'
-
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   StyleSheet,
   Text,
-} = React;
+} = ReactNative;
 
-var update = React.addons.update,
+var update = ReactNative.addons.update,
     countDown = require('./countDown');
 
 var CountDownText = React.createClass({


### PR DESCRIPTION
`createClass` was being called from react-native rather than from react. Fixed the issue by changing React to ReactNative and creating a new React variable which references react.