### PR TITLE
adapt to  newer react

### DIFF
--- a/CountDownText.js
+++ b/CountDownText.js
@@ -12,14 +12,15 @@ this.refs.countDownText.end();
 
 'use strict'
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   StyleSheet,
   Text,
-} = React;
+} = ReactNative;
 
-var update = React.addons.update,
+var update = require('react-addons-update'),
     countDown = require('./countDown');
 
 var CountDownText = React.createClass({


### PR DESCRIPTION
I found CountDownText won't work with ReactNative 44 because the way to use react in this repository is deprecated  long time ago. 